### PR TITLE
Package.json: Simple fix for scripts and add validation for node version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "starterpack",
   "version": "2.0.0",
+  "engines" : {
+    "node" : ">=6.3.0"
+  },
   "devDependencies": {
     "react-scripts": "0.8.4",
     "sw-precache": "^4.2.3"
@@ -24,9 +27,9 @@
   "scripts": {
     "build-css": "node-sass src/ -o src/",
     "watch-css": "npm run build-css && node-sass src/ -o src/ --watch",
-    "start-js": "sh -ac '. .env.local; react-scripts start'",
+    "start-js": "sh -ac '. ./.env.local; react-scripts start'",
     "start": "npm-run-all -p watch-css start-js",
-    "build": "npm run build-css && sh -ac '. .env.${REACT_APP_ENV}; react-scripts build' && cp manifest.json build/ && sw-precache --root='build/' --static-file-globs='build/**/!(*map*)'",
+    "build": "npm run build-css && sh -ac './.env.${REACT_APP_ENV}; react-scripts build' && cp manifest.json build/ && sw-precache --root='build/' --static-file-globs='build/**/!(*map*)'",
     "build:staging": "REACT_APP_ENV=staging npm run build",
     "build:production": "REACT_APP_ENV=production npm run build",
     "test": "react-scripts test --env=jsdom",


### PR DESCRIPTION
After trying to execute the thread start command, I viewed some improvements for package.json, these changes consist of:
- Add supported version of engines using the feature [engines](https://docs.npmjs.com/files/package.json#engines).

- Fix scripts syntax for the commands: [start-js](https://github.com/Danjavia/PWA-ReactJS-Starter-Pack/blob/master/package.json#L27), [build](https://github.com/Danjavia/PWA-ReactJS-Starter-Pack/blob/master/package.json#L29).
 The reason you could not perform this task is an apparent misunderstanding of file location:
 **Before:** 
 ``"sh -ac '. .env.local; react-scripts start'"``
 **After:**
``"sh -ac '. ./.env.local; react-scripts start'"``


###### _Note: This changes have been tested in Ubuntu 16.04 &  14.04._